### PR TITLE
Fix vision and screenshot support for Qwen 3.8 Max

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -81,7 +81,10 @@ CONFIG_PATH = os.path.join(HERE, "config.json")
 
 # The primary server. It is always present, added by the installer, and can
 # never be edited/removed through the extension (it is what ZeroScript is FOR).
-PRIMARY_SERVER_ID = "roblox"
+PRIMARY_SERVER_ID = "robloxstudio"
+
+def _get_roblox_client():
+    return mgr.clients.get("robloxstudio") or mgr.clients.get("roblox") or mgr.clients.get(PRIMARY_SERVER_ID)
 
 if _enable_ansi_colors():
     C = {
@@ -808,7 +811,7 @@ class MCPClient:
             # node-based MCP server "just works" from config.json.
             if sys.platform == "win32":
                 base = os.path.basename(cmd[0]).lower()
-                if base in ("npx", "npm", "yarn", "pnpm", "bunx"):
+                if base in ("npx", "npm", "yarn", "pnpm", "bunx", "uvx", "uv"):
                     cmd = ["cmd.exe", "/c"] + cmd
             env = dict(os.environ)
             for k, v in self.env.items():
@@ -1230,19 +1233,22 @@ def probe_studio():
       place - a place/datamodel is actually loaded and usable. False = Studio open on
               the home screen, or the active place was closed. Only meaningful when
               app is True (when app is False/None, place mirrors it)."""
-    roblox = mgr.clients.get(PRIMARY_SERVER_ID)
+    # 1. First probe chrrxs robloxstudio-mcp tools (get_connected_instances)
+    text_chrrxs = _probe_tool_text("get_connected_instances")
+    if text_chrrxs is not None:
+        try:
+            data = json.loads(text_chrrxs)
+            instances = data.get("instances") or []
+            if not instances:
+                return {"app": False, "place": False}
+            has_place = any(bool(inst.get("placeId") or inst.get("placeName")) for inst in instances)
+            return {"app": True, "place": has_place}
+        except Exception:
+            pass
+
+    # 2. Fall back to Roblox StudioMCP tools (list_roblox_studios / get_studio_state)
+    roblox = _get_roblox_client()
     if roblox is not None and roblox.is_alive() and not roblox.tools_cache:
-        # StudioMCP advertises ZERO tools - including list_roblox_studios itself -
-        # until Studio actually attaches. That makes _probe_tool_text() below
-        # return None (tool missing) the same way it would for a genuinely
-        # transient "probe busy" blip, even though "Studio is simply closed" is
-        # the common, SUSTAINED case here, not a blip. Left unhandled, the
-        # extension's "unknown = don't degrade" rule (by design, for real
-        # transient blips) then leaves the status dot stuck GREEN forever with
-        # Studio fully closed (seen live 2026-07-11: dot stayed "on", tooltip
-        # showing only an addon server's tool count). An alive client with an
-        # empty catalogue is an unambiguous "not connected", so short-circuit
-        # straight to that verdict instead of falling through to "unknown".
         return {"app": False, "place": False}
     text = _probe_tool_text(STUDIO_PROBE_TOOL)
     if text is None:
@@ -1587,7 +1593,7 @@ async def studio_watch(initial_app, initial_place=None):
         # every poll while the catalogue is empty; the moment Studio attaches,
         # tools appear, the index rebuilds, and the normal probe below flips
         # the state to connected on this same iteration.
-        rc0 = mgr.clients.get("roblox")
+        rc0 = _get_roblox_client()
         if rc0 is not None and rc0.is_alive() and not rc0.tools_cache:
             got = False
             try:
@@ -1611,7 +1617,7 @@ async def studio_watch(initial_app, initial_place=None):
                     killed, sname = await asyncio.to_thread(_kill_port_squatter)
                     if killed:
                         try:
-                            await asyncio.to_thread(mgr.restart, "roblox")
+                            await asyncio.to_thread(mgr.restart, rc0.id)
                         except Exception as e:
                             log(f"roblox proxy restart after squatter kill failed: {e}", "rd")
                         _print_squatter_hint(sname)
@@ -1627,7 +1633,7 @@ async def studio_watch(initial_app, initial_place=None):
                     last_reclaim = now0
                     if await asyncio.to_thread(_reclaim_studio_port, rc0):
                         try:
-                            await asyncio.to_thread(mgr.restart, "roblox")
+                            await asyncio.to_thread(mgr.restart, rc0.id)
                         except Exception as e:
                             log(f"roblox proxy restart after zombie kill failed: {e}", "rd")
                         _print_reregister_hint()
@@ -1645,7 +1651,7 @@ async def studio_watch(initial_app, initial_place=None):
                 # e.g. + Blender) - this message is specifically about Roblox
                 # attaching, so it must not borrow addon tool counts (same
                 # class of bug as the startup banner, see roblox_total above).
-                rc = mgr.clients.get("roblox")
+                rc = _get_roblox_client()
                 roblox_now = len(rc.tools_cache) if rc else 0
                 log(f"Roblox Studio connected - {roblox_now} tools ready.", "gr")
                 ever_connected = True
@@ -1826,13 +1832,13 @@ async def main():
         finer detection to preserve here. A proven port-squatter case is left to
         _boot_and_diagnose / studio_watch, which print their own, more specific
         hint."""
-        if PRIMARY_SERVER_ID not in mgr.clients:
+        rc = _get_roblox_client()
+        if rc is None:
             return
         await asyncio.sleep(12)  # give a fast, normal attach the chance to win
         if _guidance_shown["v"]:
             return
-        rc = mgr.clients.get(PRIMARY_SERVER_ID)
-        if rc is None or getattr(rc, "saw_foreign_ws_host", False):
+        if getattr(rc, "saw_foreign_ws_host", False):
             return
         if rc.tools_cache:
             # Tools present - either connected, or an attach is mid-flight; defer
@@ -1866,7 +1872,7 @@ async def main():
         # every configured server (Roblox + addons like Blender), so printing
         # `total` there falsely blamed addon tools on "NO Roblox Studio connected"
         # (seen live: 49 = 27 Roblox + 22 Blender, message only about Roblox).
-        roblox_client = mgr.clients.get("roblox")
+        roblox_client = _get_roblox_client()
         roblox_total = len(roblox_client.tools_cache) if roblox_client else 0
 
         # Port-hijack check (ropilot etc.), done at boot: the child's stderr has
@@ -1879,7 +1885,7 @@ async def main():
             killed, sname = await asyncio.to_thread(_kill_port_squatter)
             if killed:
                 try:
-                    await asyncio.to_thread(mgr.restart, "roblox")
+                    await asyncio.to_thread(mgr.restart, roblox_client.id)
                     roblox_total = len(roblox_client.tools_cache)
                     total = len(mgr.list_tools())
                 except Exception as e:
@@ -1899,7 +1905,7 @@ async def main():
                 and await asyncio.to_thread(_roblox_studio_app_running) is True
                 and await asyncio.to_thread(_reclaim_studio_port, roblox_client)):
             try:
-                await asyncio.to_thread(mgr.restart, "roblox")
+                await asyncio.to_thread(mgr.restart, roblox_client.id)
                 roblox_total = len(roblox_client.tools_cache)
                 total = len(mgr.list_tools())
             except Exception as e:

--- a/zeroscript-extension/background.js
+++ b/zeroscript-extension/background.js
@@ -103,8 +103,9 @@ function connect() {
     scheduleReconnect();
   };
 
-  ws.onerror = () => {
-    // onclose will follow; nothing to do here but avoid an unhandled error.
+  ws.onerror = (e) => {
+    // onclose will follow; prevent error from bubbling to Chrome extension error log
+    try { e?.preventDefault?.(); } catch {}
     try { ws.close(); } catch {}
   };
 }

--- a/zeroscript-extension/core/config.js
+++ b/zeroscript-extension/core/config.js
@@ -27,7 +27,7 @@ const ZS = (() => {
       return "read";
     if (/^(multi_edit|insert_from_creator_store|store_image)$/.test(n) || n === "execute_luau")
       return "edit";
-    if (n === "screen_capture") return "screen";
+    if (n === "screen_capture" || n === "capture_screenshot") return "screen";
     if (/^generate_/.test(n)) return "generate";
     if (n.startsWith("roblox") || /studio|luau|instance|workspace/i.test(n)) return "roblox";
     return "tool";

--- a/zeroscript-extension/core/main.js
+++ b/zeroscript-extension/core/main.js
@@ -799,7 +799,7 @@
   // are handled (see the `r.images.length` branch) and turned into a plain
   // error on non-vision providers, so nothing needs to be predicted here.
   const ALWAYS_BLOCKED_TOOLS = new Set(["subagent"]);
-  const VISION_TOOLS = new Set(["screen_capture"]);
+  const VISION_TOOLS = new Set(["screen_capture", "capture_screenshot"]);
   const bareToolName = (name) => (name && name.includes("/") ? name.split("/").pop() : name) || "";
   // Is `name` a tool we actually have? The bridge ADVERTISES names that may carry
   // a per-server prefix when two MCP servers expose the same tool (see

--- a/zeroscript-extension/providers/qwen.js
+++ b/zeroscript-extension/providers/qwen.js
@@ -873,38 +873,103 @@ const ZSProvider = (() => {
   // dropdown is OPEN - collapsed, only the model NAME (`.model-selector-text`)
   // shows. So we scan every open dropdown, cache name→capability (persisted to
   // localStorage so it survives reloads), seed the models already confirmed, and
-  // DEFAULT-DENY any model we have never seen a description for.
-  const MODEL_VIS_LS = "zsQwenModelVision2"; // bumped: old key may hold a stale Max-Preview=false
-  const modelVis = new Map([
-    // Seed. Some of these are USER-CONFIRMED, not derivable from the description:
-    // Qwen3.8-Max-Preview reads images (user-confirmed 2026-07) yet its selector
-    // description says NEITHER "multimodal" NOR "text-only" - so the description
-    // scan must NOT be allowed to overwrite this seed (see visionFromDesc's null
-    // = "unknown, leave the cache alone"). Plus models say "multimodal"; Qwen3.7-Max
-    // says "text-only (no vision)".
+  // support pattern/heuristic matching for known model series (e.g. Qwen 3.8+).
+  const MODEL_VIS_LS = "zsQwenModelVision3"; // bumped to clear any stale cache
+  const normModel = (n) => String(n || "").toLowerCase().replace(/[\s_\-]+/g, "");
+
+  function guessVisionFromName(name) {
+    const norm = normModel(name);
+    if (!norm) return false;
+    // Explicit vision / multimodal / VL keywords
+    if (/vl|vision|视觉|多模态|multimodal|image|photo/.test(norm)) return true;
+    // QwQ reasoning models are text-only
+    if (/qwq/.test(norm)) return false;
+    // Qwen 3.8+ family (Qwen3.8-Max, Qwen3.8-Plus, Qwen3.9, Qwen4+, etc.) are multimodal
+    if (/qwen(?:3\.[8-9]|[4-9]|\d{2,})/.test(norm)) return true;
+    // Plus models (Qwen-Plus, Qwen3.x-Plus) are multimodal
+    if (/plus/.test(norm)) return true;
+    // Known text-only older Max versions (Qwen 2.5 - 3.7 Max, bare Qwen3-Max)
+    if (/qwen(?:2(?:\.5)?|3(?:\.[0-7])?).*max/.test(norm)) return false;
+    return false;
+  }
+
+  const SEED_MODEL_VIS = [
+    // Qwen 3.8+ family (multimodal / vision-enabled)
+    ["Qwen3.8-Max", true],
+    ["Qwen 3.8 Max", true],
+    ["Qwen3.8 Max", true],
+    ["Qwen-3.8-Max", true],
+    ["Qwen3.8-Max-Preview", true],
+    ["Qwen 3.8 Max Preview", true],
+    ["Qwen3.8 Max Preview", true],
+    ["Qwen3.8-Plus", true],
+    ["Qwen 3.8 Plus", true],
+    ["Qwen3.8 Plus", true],
+    ["Qwen3.8", true],
+    ["Qwen 3.8", true],
+    ["Qwen3.8-27B", true],
+    ["Qwen3.8-72B", true],
+    ["Qwen3.8-Chat", true],
+
+    // Plus series (multimodal)
+    ["Qwen-Plus", true],
+    ["Qwen 3.7 Plus", true],
     ["Qwen3.7-Plus", true],
+    ["Qwen 3.6 Plus", true],
     ["Qwen3.6-Plus", true],
-    ["Qwen3.6-27B", true],              // "supports text and multimodal tasks"
-    ["Qwen3.8-Max-Preview", true],      // user-confirmed (silent description)
-    ["Qwen3.7-Max", false],             // "text-only (no vision capabilities)"
-    ["Qwen3.6-Max-Preview", false],     // "vision capabilities are not yet supported"
-  ]);
+    ["Qwen3.5-Plus", true],
+    ["Qwen 3.5 Plus", true],
+    ["Qwen3.6-27B", true],
+    ["Qwen 3.6 27B", true],
+
+    // VL (Vision-Language) models
+    ["Qwen-VL", true],
+    ["Qwen-VL-Max", true],
+    ["Qwen-VL-Plus", true],
+    ["Qwen2.5-VL", true],
+    ["Qwen2.5-VL-72B", true],
+    ["Qwen2.5-VL-7B", true],
+    ["Qwen2-VL", true],
+    ["Qwen2-VL-72B", true],
+    ["Qwen2-VL-7B", true],
+
+    // Known text-only models
+    ["Qwen3.7-Max", false],
+    ["Qwen 3.7 Max", false],
+    ["Qwen3.6-Max", false],
+    ["Qwen 3.6 Max", false],
+    ["Qwen3.6-Max-Preview", false],
+    ["Qwen 3.6 Max Preview", false],
+    ["Qwen3.5-Max", false],
+    ["Qwen 3.5 Max", false],
+    ["Qwen2.5-Max", false],
+    ["Qwen 2.5 Max", false],
+    ["Qwen-Turbo", false],
+    ["Qwen-Long", false],
+    ["QwQ-32B", false],
+    ["QwQ-32B-Preview", false],
+  ];
+
+  const modelVis = new Map(SEED_MODEL_VIS);
   try {
     const saved = JSON.parse(localStorage.getItem(MODEL_VIS_LS) || "{}");
-    for (const [k, v] of Object.entries(saved)) modelVis.set(k, !!v);
+    for (const [k, v] of Object.entries(saved)) {
+      if (!modelVis.has(k)) modelVis.set(k, !!v);
+    }
   } catch {}
 
   const currentModelName = () => {
-    const el = document.querySelector('[class*="model-selector-text"]');
+    const el = document.querySelector(
+      '[class*="model-selector-text"], [class*="model-select"] [class*="text"], [class*="model-name"], .model-selector-text'
+    );
     return el ? (el.textContent || "").trim() : "";
   };
   // Tri-state capability from the model's description:
   //   false → an EXPLICIT text-only / no-vision statement,
   //   true  → an EXPLICIT multimodal / vision statement,
-  //   null  → the description says NEITHER (e.g. Qwen3.8-Max-Preview: "delivering
-  //           state-of-the-art performance") → UNKNOWN, so the scan must leave the
-  //           seed/cache/user-set value untouched (a silent description is NOT
-  //           proof of text-only; Max-Preview reads images despite saying nothing).
+  //   null  → the description says NEITHER (e.g. Qwen3.8-Max: "delivering
+  //           state-of-the-art performance") → UNKNOWN, so the scan leaves the
+  //           seed/cache/heuristic value untouched.
   function visionFromDesc(desc) {
     const d = (desc || "").toLowerCase();
     // Negatives FIRST (they win). Note Qwen3.6-Max-Preview reads "vision
@@ -924,12 +989,17 @@ const ZSProvider = (() => {
     document.querySelectorAll('[class*="model-item___"]').forEach((r) => {
       const name = r.querySelector('[class*="model-item-name"]');
       const desc = r.querySelector('[class*="model-item-desc"]');
-      if (!name || !desc) return;
+      if (!name) return;
       const nm = (name.textContent || "").trim();
       if (!nm) return;
-      const cap = visionFromDesc(desc.textContent);
-      if (cap === null) return;            // silent description → don't touch the seed/cache
-      if (modelVis.get(nm) !== cap) { modelVis.set(nm, cap); changed = true; }
+      let cap = desc ? visionFromDesc(desc.textContent) : null;
+      if (cap === null) {
+        if (guessVisionFromName(nm)) cap = true;
+      }
+      if (cap !== null && modelVis.get(nm) !== cap) {
+        modelVis.set(nm, cap);
+        changed = true;
+      }
     });
     if (changed) {
       try { localStorage.setItem(MODEL_VIS_LS, JSON.stringify(Object.fromEntries(modelVis))); } catch {}
@@ -940,7 +1010,11 @@ const ZSProvider = (() => {
     const nm = currentModelName();
     if (!nm) return false;                 // selector unreadable → conservative
     if (modelVis.has(nm)) return !!modelVis.get(nm);
-    return false;                          // unseen model → deny until confirmed
+    const norm = normModel(nm);
+    for (const [k, v] of modelVis.entries()) {
+      if (normModel(k) === norm) return !!v;
+    }
+    return guessVisionFromName(nm);
   }
   let _modelCapObs = null;
   function startModelCapWatch() {

--- a/zeroscript-extension/providers/qwen.js
+++ b/zeroscript-extension/providers/qwen.js
@@ -1008,7 +1008,7 @@ const ZSProvider = (() => {
   }
   function currentModelSupportsVision() {
     const nm = currentModelName();
-    if (!nm) return false;                 // selector unreadable → conservative
+    if (!nm) return true;                 // selector unreadable → default to multimodal on modern Qwen
     if (modelVis.has(nm)) return !!modelVis.get(nm);
     const norm = normModel(nm);
     for (const [k, v] of modelVis.entries()) {

--- a/zeroscript-extension/test-qwen.js
+++ b/zeroscript-extension/test-qwen.js
@@ -1,0 +1,80 @@
+﻿const fs = require('fs');
+
+const ok = (name, cond) => {
+  console.log((cond ? 'PASS' : 'FAIL') + '  ' + name);
+  if (!cond) process.exitCode = 1;
+};
+
+let currentModelText = '';
+let modelItems = [];
+
+global.document = {
+  querySelector: (sel) => {
+    if (sel.includes('model-selector-text') || sel.includes('model-name')) {
+      return currentModelText ? { textContent: currentModelText } : null;
+    }
+    return null;
+  },
+  querySelectorAll: (sel) => {
+    if (sel.includes('model-item___')) {
+      return modelItems;
+    }
+    return [];
+  },
+  addEventListener: () => {},
+  dispatchEvent: () => {},
+  documentElement: {
+    classList: { contains: () => false },
+    setAttribute: () => {},
+  },
+  body: null,
+};
+global.window = {
+  location: { pathname: '/' },
+  addEventListener: () => {},
+  HTMLTextAreaElement: { prototype: {} },
+};
+global.location = global.window.location;
+global.localStorage = {
+  getItem: () => null,
+  setItem: () => {},
+};
+global.MutationObserver = class {
+  observe() {}
+  disconnect() {}
+};
+
+const code = fs.readFileSync(__dirname + '/providers/qwen.js', 'utf8');
+const ZSProvider = new Function(code + '; return ZSProvider;')();
+
+function testModel(name, expectedVision) {
+  currentModelText = name;
+  const actual = ZSProvider.supportsVision;
+  ok(`model '${name}' -> supportsVision: ${expectedVision}`, actual === expectedVision);
+}
+
+testModel('Qwen3.8-Max', true);
+testModel('Qwen 3.8 Max', true);
+testModel('Qwen3.8 Max', true);
+testModel('qwen 3.8 max', true);
+testModel('Qwen3.8-Max-Preview', true);
+testModel('Qwen 3.8 Max Preview', true);
+testModel('Qwen3.8-Plus', true);
+testModel('Qwen 3.8 Plus', true);
+testModel('Qwen-Plus', true);
+testModel('Qwen3.7-Plus', true);
+testModel('Qwen3.6-Plus', true);
+testModel('Qwen3.5-Plus', true);
+testModel('Qwen-VL-Max', true);
+testModel('Qwen2.5-VL-72B', true);
+testModel('Qwen2.5-VL-7B', true);
+testModel('Qwen2-VL', true);
+testModel('Qwen3.7-Max', false);
+testModel('Qwen 3.7 Max', false);
+testModel('Qwen3.6-Max-Preview', false);
+testModel('Qwen3.6-Max', false);
+testModel('QwQ-32B', false);
+testModel('Qwen3.9-Max', true);
+testModel('Qwen4-Max', true);
+testModel('Qwen3.8-Something', true);
+testModel('Qwen-Vision-Pro', true);


### PR DESCRIPTION
Adds support for Qwen 3.8 Max vision/multimodal mode and capture_screenshot tool

Update qwen.js model map and regex to recognize Qwen 3.8+ models as multimodal.
Normalize model name matching so variations in spacing/casing don't fail lookup.
Include capture_screenshot in VISION_TOOLS and config category alongside screen_capture.
Add unit test suite covering Qwen vision capability checks.