### PR TITLE
Support kimi.ai domain for Kimi provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Control Roblox Studio with AI directly from your browser - read/edit scripts, ru
 
 > 🌐 **Website: [zerodev.tools/zeroscript](https://zerodev.tools/zeroscript)** the free Lemonade.gg / Luamotion alternative for building Roblox games with AI.
 
-Eight AI providers are supported: **DeepSeek** (chat.deepseek.com, recommended), **ChatGPT** (chatgpt.com), **Google Gemini** (gemini.google.com), **Kimi** (kimi.com, Moonshot AI), **GLM** (chat.z.ai, Z.ai), **Qwen** (chat.qwen.ai), **Arena** (arena.ai, a multi-model playground) and **Meta AI** (meta.ai). On ChatGPT, screenshots and image input are turned off on purpose: the free tier limits files and images on a separate quota from messages, so vision would only work part of the day. Gemini and Kimi can be unstable: Gemini tends to stop using the Roblox tools in long sessions, and Kimi sometimes uses its own native tools instead of the Roblox commands. On Arena, use **Direct** mode (ZeroScript only supports Direct; it blocks Start in Battle / Side-by-Side / Agent modes). DeepSeek is the recommended provider.
+Eight AI providers are supported: **DeepSeek** (chat.deepseek.com, recommended), **ChatGPT** (chatgpt.com), **Google Gemini** (gemini.google.com), **Kimi** (kimi.ai, Moonshot AI), **GLM** (chat.z.ai, Z.ai), **Qwen** (chat.qwen.ai), **Arena** (arena.ai, a multi-model playground) and **Meta AI** (meta.ai). On ChatGPT, screenshots and image input are turned off on purpose: the free tier limits files and images on a separate quota from messages, so vision would only work part of the day. Gemini and Kimi can be unstable: Gemini tends to stop using the Roblox tools in long sessions, and Kimi sometimes uses its own native tools instead of the Roblox commands. On Arena, use **Direct** mode (ZeroScript only supports Direct; it blocks Start in Battle / Side-by-Side / Agent modes). DeepSeek is the recommended provider.
 
 > 💬 **Stuck? Join the [Discord community](https://discord.gg/9aNyZsMWcb)** get help, share feedback, and follow updates.
 
@@ -64,9 +64,9 @@ A small window opens, that means the Bridge is running.
 
 ### 4. Start a session
 
-Go to https://chat.deepseek.com (recommended), https://chatgpt.com, https://gemini.google.com, https://www.kimi.com, https://chat.z.ai, https://chat.qwen.ai, https://arena.ai or https://www.meta.ai and open a new chat. The ZeroScript bar appears above the input box. Click **Start session**. Type what you want to build.
+Go to https://chat.deepseek.com (recommended), https://chatgpt.com, https://gemini.google.com, https://www.kimi.ai, https://chat.z.ai, https://chat.qwen.ai, https://arena.ai or https://www.meta.ai and open a new chat. The ZeroScript bar appears above the input box. Click **Start session**. Type what you want to build.
 
-> Only works on chat.deepseek.com, chatgpt.com, gemini.google.com, kimi.com, chat.z.ai, chat.qwen.ai, arena.ai and meta.ai - it will not work on any other site.
+> Only works on chat.deepseek.com, chatgpt.com, gemini.google.com, www.kimi.ai (or kimi.com), chat.z.ai, chat.qwen.ai, arena.ai and meta.ai - it will not work on any other site.
 > On Arena, keep the mode dropdown on **Direct** - ZeroScript blocks Start in Battle / Side-by-Side / Agent modes (it only drives a single Direct reply).
 > Gemini and Kimi can be unstable (model behavior, not the extension): Gemini may stop using the Roblox tools after a while, and Kimi may use its own native tools instead. If the AI starts answering in plain text instead of acting, remind it to use the commands or start a new session.
 ### 5. Watch the setup tutorial

--- a/zeroscript-extension/README.md
+++ b/zeroscript-extension/README.md
@@ -18,7 +18,7 @@ It's a Chrome/Edge browser extension plus a small local bridge that connects the
 2. **Open Roblox Studio** and load a Place
 3. **Enable the MCP server in Roblox Studio** (first time only): click **Assistant AI** in the top bar, then **...** > **Manage MCP Servers** > **Enable Studio as MCP Server**
 4. **Run the Bridge** - double-click `start.bat` (Windows) or `MacOS_Start.command` (macOS); a small window opens, the Bridge is running. On macOS, the first launch shows a Gatekeeper warning (normal for any downloaded script): click **Done**, then **System Settings > Privacy & Security**, scroll down, and click **Open Anyway**.
-5. **Go to https://chat.deepseek.com** (recommended), https://chatgpt.com, https://gemini.google.com, https://www.kimi.com, https://chat.z.ai, https://chat.qwen.ai, https://arena.ai, or https://www.meta.ai, open a new chat (only works on these exact addresses; on Arena use Direct mode)
+5. **Go to https://chat.deepseek.com** (recommended), https://chatgpt.com, https://gemini.google.com, https://www.kimi.ai, https://chat.z.ai, https://chat.qwen.ai, https://arena.ai, or https://www.meta.ai, open a new chat (only works on these exact addresses; on Arena use Direct mode)
 6. Click **Start session** in the ZeroScript panel
 7. Type what you want to build
 
@@ -36,8 +36,8 @@ providers/deepseek.js everything DeepSeek-specific: DOM selectors, generation
                       detection, send mechanics, composer modes…       (global ZSProvider)
 providers/gemini.js   same interface for Google Gemini (Angular DOM, Quill
                       composer, code-block masking)                    (global ZSProvider)
-providers/kimi.js     same interface for Kimi / Moonshot AI (Vue DOM, Lexical
-                      composer, segment-code masking)                  (global ZSProvider)
+providers/kimi.js     same interface for Kimi / Moonshot AI (kimi.ai / Vue DOM,
+                      Lexical composer, segment-code masking)          (global ZSProvider)
 providers/glm.js      same interface for GLM / Z.ai (Svelte DOM, code-block
                       wrapper masking)                                 (global ZSProvider)
 providers/qwen.js     same interface for Qwen / chat.qwen.ai (Vue DOM, network-tap

--- a/zeroscript-extension/background.js
+++ b/zeroscript-extension/background.js
@@ -13,7 +13,7 @@ const URL = `ws://127.0.0.1:${PORT}`;
 // Chat sites where a ZeroScript provider content script runs. Status pushes go
 // to every tab matching these. Add the new provider's URL pattern here (and in
 // manifest.json content_scripts + host_permissions) when integrating another AI.
-const PROVIDER_URLS = ["https://chat.deepseek.com/*", "https://chatgpt.com/*", "https://chat.openai.com/*", "https://gemini.google.com/*", "https://www.kimi.com/*", "https://kimi.com/*", "https://chat.z.ai/*", "https://chat.qwen.ai/*", "https://arena.ai/*", "https://www.meta.ai/*", "https://meta.ai/*"];
+const PROVIDER_URLS = ["https://chat.deepseek.com/*", "https://chatgpt.com/*", "https://chat.openai.com/*", "https://gemini.google.com/*", "https://www.kimi.com/*", "https://kimi.com/*", "https://www.kimi.ai/*", "https://kimi.ai/*", "https://chat.z.ai/*", "https://chat.qwen.ai/*", "https://arena.ai/*", "https://www.meta.ai/*", "https://meta.ai/*"];
 
 const RECONNECT_MIN = 1000;
 const RECONNECT_MAX = 5000;

--- a/zeroscript-extension/core/main.js
+++ b/zeroscript-extension/core/main.js
@@ -105,7 +105,7 @@
     { name: "DeepSeek", url: "https://chat.deepseek.com/" },
     { name: "ChatGPT", url: "https://chatgpt.com/" },
     { name: "Gemini", url: "https://gemini.google.com/app" },
-    { name: "Kimi", url: "https://www.kimi.com/" },
+    { name: "Kimi", url: "https://www.kimi.ai/" },
     { name: "GLM", url: "https://chat.z.ai/" },
     { name: "Qwen", url: "https://chat.qwen.ai/" },
     { name: "Arena", url: "https://arena.ai/text/direct" },

--- a/zeroscript-extension/manifest.json
+++ b/zeroscript-extension/manifest.json
@@ -12,6 +12,8 @@
     "https://gemini.google.com/*",
     "https://www.kimi.com/*",
     "https://kimi.com/*",
+    "https://www.kimi.ai/*",
+    "https://kimi.ai/*",
     "https://chat.z.ai/*",
     "https://chat.qwen.ai/*",
     "https://arena.ai/*",
@@ -63,7 +65,12 @@
       "run_at": "document_idle"
     },
     {
-      "matches": ["https://www.kimi.com/*", "https://kimi.com/*"],
+      "matches": [
+        "https://www.kimi.com/*",
+        "https://kimi.com/*",
+        "https://www.kimi.ai/*",
+        "https://kimi.ai/*"
+      ],
       "js": ["core/config.js", "core/parser.js", "providers/kimi.js", "core/main.js"],
       "css": ["overlay.css"],
       "run_at": "document_idle"

--- a/zeroscript-extension/popup.js
+++ b/zeroscript-extension/popup.js
@@ -2,7 +2,7 @@
 const KOFI_URL = "https://ko-fi.com/sebattfg";
 const SUPPORTED_HOSTS = [
   "chat.deepseek.com", "deepseek.com", "chatgpt.com", "chat.openai.com",
-  "gemini.google.com", "www.kimi.com", "kimi.com",
+  "gemini.google.com", "www.kimi.com", "kimi.com", "www.kimi.ai", "kimi.ai",
   "chat.z.ai", "chat.qwen.ai", "arena.ai", "www.meta.ai", "meta.ai",
 ];
 const DEFAULT_AI_URL = "https://chat.deepseek.com/";

--- a/zeroscript-extension/providers/kimi.js
+++ b/zeroscript-extension/providers/kimi.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// providers/kimi.js - the Kimi (www.kimi.com, Moonshot AI) provider.
+// providers/kimi.js - the Kimi (kimi.ai / www.kimi.com, Moonshot AI) provider.
 // Exports the same ZSProvider interface as providers/deepseek.js and gemini.js;
 // the core (core/main.js) is provider-agnostic. To DISABLE Kimi support, remove
 // this file from manifest.json (and its URL from background.js PROVIDER_URLS +


### PR DESCRIPTION
Kimi rebranded from kimi.com to kimi.ai. This adds kimi.ai and www.kimi.ai to the manifest host permissions, content scripts, background provider URLs, and popup host list, updates the site link to https://www.kimi.ai/, and keeps backwards compatibility for kimi.com.